### PR TITLE
Fixing issues with the primary server configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,42 +5,23 @@ resource "null_resource" "postgresql-read-replica" {
     postgresql_replica_server_name = var.postgresql_replica_server_name
   }
 
-  # enables replication on the primary server
-  provisioner "local-exec" {
-    command = <<ENABLE_REPLICATION
-az postgres server configuration set \
-  --resource-group ${var.resource_group_name} \
-  --server-name ${var.postgresql_primary_server_name} \
-  --name azure.replication_support --value REPLICA
-ENABLE_REPLICATION
-  }
-
-  # restart primary for change to take effect
-  provisioner "local-exec" {
-    command = <<RESTART_SERVER
-az postgres server restart \
-  --name ${var.postgresql_primary_server_name} \
-  --resource-group ${var.resource_group_name}
-RESTART_SERVER
-  }
-
   # create replica
   provisioner "local-exec" {
     command = <<CREATE_REPLICA
 az postgres server replica create \
-  --name ${var.postgresql_replica_server_name} \
-  --source-server ${var.postgresql_primary_server_name} \
-  --resource-group ${var.resource_group_name}
+  --name ${self.triggers.postgresql_replica_server_name} \
+  --source-server ${self.triggers.postgresql_primary_server_name} \
+  --resource-group ${self.triggers.resource_group_name}
 CREATE_REPLICA
   }
 
   provisioner "local-exec" {
-    when = "destroy" 
+    when = destroy
     command = <<DESTROY_REPLICA
 az postgres server delete \
-  --name ${var.postgresql_replica_server_name} \
-  --resource-group ${var.resource_group_name} \
+  --name ${self.triggers.postgresql_replica_server_name} \
+  --resource-group ${self.triggers.resource_group_name} \
   --yes
-DESTROY_REPLICA    
+DESTROY_REPLICA
   }
 }


### PR DESCRIPTION
I tried using this module but I hit the following problems and warnings:

1. It seems that Azure enables the replication on new PostgreSQL servers by default.

Because of that the `ENABLE_REPLICATION` step is failing. I tested executing the command from the terminal and I am hitting the same problem.

```sh
$ az postgres server configuration set \
  --resource-group some-rg \
  --server-name some-postgresql \
  --name azure.replication_support --value REPLICA

Deployment failed. Correlation ID: some-correlation-id. Invalid value given for parameter 'azure.replication_support'. Specify a valid parameter value.
```

According to the [Azure Docs](https://docs.microsoft.com/en-gb/azure/postgresql/howto-read-replicas-cli#prepare-the-master-server) that error is expected because the replication is already enabled.

However when I list my PostgreSQL server configuration I get the following output:

```sh
{
  "allowedValues": "OFF,REPLICA,LOGICAL",
  "dataType": "Enumeration",
  "defaultValue": "OFF",
  "description": "Sets the level of replication support (Read Replicas). Any change requires restarting the server to take effect. This setting should not be changed for Basic servers.",
  "id": "/subscriptions/some-id/resourceGroups/some-rg/providers/Microsoft.DBforPostgreSQL/servers/some-postgresql/configurations/azure.replication_support",
  "name": "azure.replication_support",
  "resourceGroup": "some-rg",
  "source": "system-default",
  "type": "Microsoft.DBforPostgreSQL/servers/configurations",
  "value": "OFF"
}
```
From the Azure Portal the option for disabling the replication is greyed out and I can create replicas manually via the Portal. 

![image](https://user-images.githubusercontent.com/5238255/73844470-4ebba200-4829-11ea-9ef2-c0aec0d878d6.png)

I am assuming that Azure are deprecating the `azure.replication_support` option because the PostgreSQL servers will have the replication option enabled by default.

2. WARNING: External references from destroy provisioners are deprecated

I managed to fix that by getting the variables from the `self` object.